### PR TITLE
Fix Docker images (adds -allow-share to ENTRYPOINT)

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,16 +1,15 @@
 FROM debian:jessie
 
-RUN apt-key update && apt-get update
-RUN apt-get install -y ca-certificates
+RUN apt-key update && \
+    apt-get update && \
+    apt-get install -y ca-certificates && \
+    mkdir /var/app -p && \
+    mkdir /var/data -p
 
 COPY app_linux_amd64 /bin/app
-
-RUN mkdir /var/app -p
-
-RUN mkdir /var/data -p
 
 COPY static /var/app/static
 
 WORKDIR /var/app
 
-ENTRYPOINT [ "/bin/app" ]
+ENTRYPOINT [ "/bin/app", "-allow-share" ]


### PR DESCRIPTION
Condenses `RUN` statements together and adds `-allow-share` flag to `ENTRYPOINT`, so `make docker-run` will work as expected when using the standalone web app.

----

It's not too complicated, but it took a minute to figure out why the Docker image wasn't working (Error communicating with remote server) but building and compiling it was. This PR should fix this for anyone else who's wanting to run this in Docker container in the future without having to change it themselves.