### PR TITLE
Standardize Makefiles against each other, name sandbox Docker image

### DIFF
--- a/sandbox/Makefile
+++ b/sandbox/Makefile
@@ -1,14 +1,17 @@
-IMAGE_NAME ?= xiam/playgo-sandbox
+CONTAINER_IMAGE ?= xiam/playgo-sandbox
+CONTAINER_NAME 	?= go-playground-sandbox
 
 docker: Dockerfile
-	docker build -t $(IMAGE_NAME) .
+	docker build -t $(CONTAINER_IMAGE) .
 
 test: docker
 	go test
-	docker run --rm $(IMAGE_NAME) test
+	docker run --rm $(CONTAINER_IMAGE) test
 
 run:
-	docker run -d -p 8080:8080 -t $(IMAGE_NAME)
+	(docker stop $(CONTAINER_NAME) || exit 0) && \
+    (docker rm $(CONTAINER_NAME) || exit 0) && \
+	docker run -d -p 8080:8080 --name $(CONTAINER_NAME) -t $(CONTAINER_IMAGE)
 
 push:
-	docker push $(IMAGE_NAME)
+	docker push $(CONTAINER_IMAGE)

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -23,7 +23,7 @@ docker-build: require-glide require-uglifyjs
 docker-run:
 	(docker stop $(CONTAINER_NAME) || exit 0) && \
 	(docker rm $(CONTAINER_NAME) || exit 0) && \
-	docker run -d -p 127.0.0.1:3000:3000 --name $(CONTAINER_NAME) -t $(CONTAINER_IMAGE)
+	docker run -d -p 3000:3000 --name $(CONTAINER_NAME) -t $(CONTAINER_IMAGE)
 
 docker-push: docker-build
 	docker tag $(CONTAINER_IMAGE) $(CONTAINER_IMAGE):$(TAG) && \


### PR DESCRIPTION
This is really a minor change, but it made it easier to script / automate things with the go-playground-sandbox when the image was named. Since this is already happening with the webapp, I figured it would be a minor change to also do this with the sandbox. I also changed the name of the variable so that it followed the precedent in the webapp Makefile.